### PR TITLE
Fix loading templates from ClassLoader

### DIFF
--- a/src/main/php/com/github/mustache/ResourcesIn.class.php
+++ b/src/main/php/com/github/mustache/ResourcesIn.class.php
@@ -30,7 +30,7 @@ class ResourcesIn extends FileBasedTemplateLoader {
    */
   protected function inputStreamFor($name) {
     try {
-      return $this->loader->getResourceAsStream($name.'.mustache')->getInputStream();
+      return $this->base->getResourceAsStream($name)->getInputStream();
     } catch (ElementNotFoundException $e) {
       throw new TemplateNotFoundException('Cannot find template '.$name, $e);
     }


### PR DESCRIPTION
a) use correct member
b) do not hardcodedly append ".mustache" to the template name, as this
   might be overwritten per constructor-arg