### PR TITLE
Add an operation to list templates in a loader

### DIFF
--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -1,11 +1,13 @@
 <?php namespace com\github\mustache;
 
+use util\Objects;
+
 /**
  * File-based template loading loads templates from the file system.
  *
  * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
  */
-abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateLoader {
+abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateLoader, TemplateListing {
   protected $base;
   protected $extensions;
 
@@ -54,6 +56,6 @@ abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateL
     foreach ($variants as $variant) {
       if ($stream= $this->inputStreamFor($variant)) return $stream;
     }
-    throw new TemplateNotFoundException('Cannot find template ['.implode(', ', $variants).'] in '.\util\Objects::stringOf($this->base));
+    throw new TemplateNotFoundException('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));
   }
 }

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -7,9 +7,8 @@ use util\Objects;
  *
  * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
  */
-abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateLoader, TemplateListing {
-  protected $base;
-  protected $extensions;
+abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateLoader, WithListing {
+  protected $base, $extensions, $listing;
 
   /**
    * Creates a new file-based template loader
@@ -57,5 +56,24 @@ abstract class FileBasedTemplateLoader extends \lang\Object implements TemplateL
       if ($stream= $this->inputStreamFor($variant)) return $stream;
     }
     throw new TemplateNotFoundException('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));
+  }
+
+  /**
+   * Returns a function to use for listing
+   *
+   * @return function(string): string[]
+   */
+  protected abstract function entries();
+
+  /**
+   * Returns listing of templates
+   *
+   * @return  com.github.mustache.TemplateListing
+   */
+  public function listing() {
+    if (null === $this->listing) {
+      $this->listing= new TemplateListing(null, $this->entries());
+    }
+    return $this->listing;
   }
 }

--- a/src/main/php/com/github/mustache/FilesIn.class.php
+++ b/src/main/php/com/github/mustache/FilesIn.class.php
@@ -5,14 +5,16 @@ use io\File;
 
 /**
  * File-based template loading loads templates from a given folder
+ *
+ * @test  xp://com.github.mustache.unittest.FilesInTest
  */
 class FilesIn extends FileBasedTemplateLoader {
 
   /**
    * Creates a new file-based template loader
    *
-   * @param var $base The base folder, either an io.Folder or a string
-   * @param string[] $extensions File extensions to check, including leading "."
+   * @param  string|io.Folder $base The base folder
+   * @param  string[] $extensions File extensions to check, including leading "."
    */
   public function __construct($arg, $extensions= ['.mustache']) {
     parent::__construct(
@@ -29,6 +31,35 @@ class FilesIn extends FileBasedTemplateLoader {
    */
   protected function inputStreamFor($name) {
     $f= new File($this->base, $name);
-    return $f->exists() ? $f->getInputStream() : null;
+    return $f->exists() ? $f->in() : null;
+  }
+
+  /**
+   * Returns available templates
+   *
+   * @param   string $namespace Optional, omit for root namespace
+   * @return  string[]
+   */
+  public function templatesIn($namespace= null) {
+    $namespace= rtrim($namespace, '/');
+    if ('' === $namespace) {
+      $folder= $this->base;
+      $prefix= '';
+    } else {
+      $folder= new Folder($this->base, strtr($namespace, '/', DIRECTORY_SEPARATOR));
+      $prefix= $namespace.'/';
+    }
+
+    $r= [];
+    while ($entry= $folder->getEntry()) {
+      foreach ($this->extensions as $extension) {
+        $offset= -strlen($extension);
+        if (0 === substr_compare($entry, $extension, $offset)) {
+          $r[]= $prefix.substr($entry, 0, $offset);
+        }
+      }
+    }
+    $folder->rewind();
+    return $r;
   }
 }

--- a/src/main/php/com/github/mustache/FilesIn.class.php
+++ b/src/main/php/com/github/mustache/FilesIn.class.php
@@ -35,31 +35,34 @@ class FilesIn extends FileBasedTemplateLoader {
   }
 
   /**
-   * Returns available templates
+   * Returns a function to use for listing
    *
-   * @param   string $namespace Optional, omit for root namespace
-   * @return  string[]
+   * @return function(string): string[]
    */
-  public function templatesIn($namespace= null) {
-    $namespace= rtrim($namespace, '/');
-    if ('' === $namespace) {
-      $folder= $this->base;
-      $prefix= '';
-    } else {
-      $folder= new Folder($this->base, strtr($namespace, '/', DIRECTORY_SEPARATOR));
-      $prefix= $namespace.'/';
-    }
+  protected function entries() {
+    return function($package) {
+      if ('' === $package) {
+        $folder= $this->base;
+        $prefix= '';
+      } else {
+        $folder= new Folder($this->base, strtr($package, '/', DIRECTORY_SEPARATOR));
+        $prefix= $package.'/';
+      }
 
-    $r= [];
-    while ($entry= $folder->getEntry()) {
-      foreach ($this->extensions as $extension) {
-        $offset= -strlen($extension);
-        if (0 === substr_compare($entry, $extension, $offset)) {
-          $r[]= $prefix.substr($entry, 0, $offset);
+      $r= [];
+      $base= $folder->getURI();
+      while ($entry= $folder->getEntry()) {
+        if (is_dir($base.$entry)) {
+          $r[]= $prefix.$entry.'/';
+        } else foreach ($this->extensions as $extension) {
+          $offset= -strlen($extension);
+          if (0 === substr_compare($entry, $extension, $offset)) {
+            $r[]= $prefix.substr($entry, 0, $offset);
+          }
         }
       }
-    }
-    $folder->rewind();
-    return $r;
+      $folder->rewind();
+      return $r;
+    };
   }
 }

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -4,14 +4,16 @@ use io\streams\MemoryInputStream;
 
 /**
  * Template loading
+ *
+ * @test  xp://com.github.mustache.unittest.InMemoryTest
  */
-class InMemory extends \lang\Object implements TemplateLoader {
+class InMemory extends \lang\Object implements TemplateLoader, TemplateListing {
   protected $templates= [];
 
   /**
    * Creates a new in-memory template loader
    *
-   * @param [:string] templates
+   * @param  [:string] $templates
    */
   public function __construct($templates= []) {
     $this->templates= [];
@@ -52,5 +54,28 @@ class InMemory extends \lang\Object implements TemplateLoader {
     }
     $this->templates[$name]->seek(0);
     return $this->templates[$name];
+  }
+
+  /**
+   * Returns available templates
+   *
+   * @param   string $namespace Optional, omit for root namespace
+   * @return  string[]
+   */
+  public function templatesIn($namespace= null) {
+    $r= [];
+    $namespace= rtrim($namespace, '/');
+    if ('' === $namespace) {
+      foreach ($this->templates as $name => $stream) {
+        if (false === strpos($name, '/')) $r[]= $name;
+      }
+    } else {
+      $prefix= $namespace.'/';
+      $length= strlen($prefix);
+      foreach ($this->templates as $name => $stream) {
+        if (0 === strncmp($name, $prefix, $length) && false === strpos($name, '/', $length)) $r[]= $name;
+      }
+    }
+    return $r;
   }
 }

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -1,5 +1,8 @@
 <?php namespace com\github\mustache;
 
+use text\StreamTokenizer;
+use text\StringTokenizer;
+
 /**
  * The MustacheEngine is the entry point class for working with this
  * API. The easiest usage way is to call the render() method and pass
@@ -97,7 +100,7 @@ class MustacheEngine extends \lang\Object {
    */
   public function compile($template, $start= '{{', $end= '}}', $indent= '') {
     return new Template('<string>', $this->parser->parse(
-      new \text\StringTokenizer($template),
+      new StringTokenizer($template),
       $start,
       $end,
       $indent
@@ -115,7 +118,7 @@ class MustacheEngine extends \lang\Object {
    */
   public function load($name, $start= '{{', $end= '}}', $indent= '') {
     return new Template($name, $this->parser->parse(
-      new \text\StreamTokenizer($this->templates->load($name)),
+      new StreamTokenizer($this->templates->load($name)),
       $start,
       $end,
       $indent

--- a/src/main/php/com/github/mustache/ResourcesIn.class.php
+++ b/src/main/php/com/github/mustache/ResourcesIn.class.php
@@ -55,7 +55,9 @@ class ResourcesIn extends FileBasedTemplateLoader {
 
       $r= [];
       foreach ($resources as $entry) {
-        foreach ($this->extensions as $extension) {
+        if ('/' === $entry{strlen($entry) - 1}) {
+          $r[]= $prefix.$entry;
+        } else foreach ($this->extensions as $extension) {
           $offset= -strlen($extension);
           if (0 === substr_compare($entry, $extension, $offset)) {
             $r[]= $prefix.substr($entry, 0, $offset);

--- a/src/main/php/com/github/mustache/ResourcesIn.class.php
+++ b/src/main/php/com/github/mustache/ResourcesIn.class.php
@@ -39,30 +39,30 @@ class ResourcesIn extends FileBasedTemplateLoader {
   }
 
   /**
-   * Returns available templates
+   * Returns a function to use for listing
    *
-   * @param   string $namespace Optional, omit for root namespace
-   * @return  string[]
+   * @return function(string): string[]
    */
-  public function templatesIn($namespace= null) {
-    $namespace= rtrim($namespace, '/');
-    if ('' === $namespace) {
-      $resources= $this->base->packageContents(null);
-      $prefix= '';
-    } else {
-      $resources= $this->base->packageContents(strtr($namespace, '/', '.'));
-      $prefix= $namespace.'/';
-    }
+  protected function entries() {
+    return function($package) {
+      if ('' === $package) {
+        $resources= $this->base->packageContents(null);
+        $prefix= '';
+      } else {
+        $resources= $this->base->packageContents(strtr($package, '/', '.'));
+        $prefix= $package.'/';
+      }
 
-    $r= [];
-    foreach ($resources as $entry) {
-      foreach ($this->extensions as $extension) {
-        $offset= -strlen($extension);
-        if (0 === substr_compare($entry, $extension, $offset)) {
-          $r[]= $prefix.substr($entry, 0, $offset);
+      $r= [];
+      foreach ($resources as $entry) {
+        foreach ($this->extensions as $extension) {
+          $offset= -strlen($extension);
+          if (0 === substr_compare($entry, $extension, $offset)) {
+            $r[]= $prefix.substr($entry, 0, $offset);
+          }
         }
       }
-    }
-    return $r;
+      return $r;
+    };
   }
 }

--- a/src/main/php/com/github/mustache/ResourcesIn.class.php
+++ b/src/main/php/com/github/mustache/ResourcesIn.class.php
@@ -14,8 +14,8 @@ class ResourcesIn extends FileBasedTemplateLoader {
   /**
    * Creates a new class loader based template loader
    *
-   * @param var $base The delegate, either an IClassLoader or a string
-   * @param string[] $extensions File extensions to check, including leading "."
+   * @param  string|lang.IClassLoader $base A classloader path or instance
+   * @param  string[] $extensions File extensions to check, including leading "."
    */
   public function __construct($arg, $extensions= ['.mustache']) {
     parent::__construct(
@@ -36,5 +36,33 @@ class ResourcesIn extends FileBasedTemplateLoader {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Returns available templates
+   *
+   * @param   string $namespace Optional, omit for root namespace
+   * @return  string[]
+   */
+  public function templatesIn($namespace= null) {
+    $namespace= rtrim($namespace, '/');
+    if ('' === $namespace) {
+      $resources= $this->base->packageContents(null);
+      $prefix= '';
+    } else {
+      $resources= $this->base->packageContents(strtr($namespace, '/', '.'));
+      $prefix= $namespace.'/';
+    }
+
+    $r= [];
+    foreach ($resources as $entry) {
+      foreach ($this->extensions as $extension) {
+        $offset= -strlen($extension);
+        if (0 === substr_compare($entry, $extension, $offset)) {
+          $r[]= $prefix.substr($entry, 0, $offset);
+        }
+      }
+    }
+    return $r;
   }
 }

--- a/src/main/php/com/github/mustache/TemplateListing.class.php
+++ b/src/main/php/com/github/mustache/TemplateListing.class.php
@@ -1,0 +1,16 @@
+<?php namespace com\github\mustache;
+
+/**
+ * Template listing
+ */
+interface TemplateListing {
+
+  /**
+   * Returns available templates
+   *
+   * @param   string $namespace Optional, omit for root namespace
+   * @return  string[]
+   */
+  public function templatesIn($namespace= null);
+
+}

--- a/src/main/php/com/github/mustache/TemplateListing.class.php
+++ b/src/main/php/com/github/mustache/TemplateListing.class.php
@@ -1,16 +1,52 @@
 <?php namespace com\github\mustache;
 
-/**
- * Template listing
- */
-interface TemplateListing {
+class TemplateListing {
+  private $name, $entries;
 
   /**
-   * Returns available templates
+   * Creates a new instance
    *
-   * @param   string $namespace Optional, omit for root namespace
+   * @param  string $name
+   * @param  function(string): string[] $entries
+   */
+  public function __construct($name, \Closure $entries) {
+    $this->name= rtrim($name, '/');
+    $this->entries= $entries;
+  }
+
+  /**
+   * Returns templates in this listing 
+   *
    * @return  string[]
    */
-  public function templatesIn($namespace= null);
+  public function templates() {
+    $result= [];
+    foreach ($this->entries->__invoke($this->name) as $entry) {
+      if ('/' !== $entry{strlen($entry) - 1}) $result[]= $entry;
+    }
+    return $result;
+  }
 
+  /**
+   * Returns packages in this listing 
+   *
+   * @return  string[]
+   */
+  public function packages() {
+    $result= [];
+    foreach ($this->entries->__invoke($this->name) as $entry) {
+      if ('/' === $entry{strlen($entry) - 1}) $result[]= $entry;
+    }
+    return $result;
+  }
+
+  /**
+   * Returns named subpackage
+   *
+   * @param   string $name
+   * @return  self
+   */
+  public function package($name) {
+    return new self('' === $this->name ? $name : $this->name.'/'.$name, $this->entries);
+  }
 }

--- a/src/main/php/com/github/mustache/WithListing.class.php
+++ b/src/main/php/com/github/mustache/WithListing.class.php
@@ -1,0 +1,15 @@
+<?php namespace com\github\mustache;
+
+/**
+ * Template listing
+ */
+interface WithListing {
+
+  /**
+   * Returns available templates
+   *
+   * @return  com.github.mustache.TemplateListing
+   */
+  public function listing();
+
+}

--- a/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
@@ -25,12 +25,14 @@ class FileBasedTemplateLoaderTest extends \unittest\TestCase {
           return null;
         }
       },
-      'templatesIn' => function($package= null) {
-        if ('' === rtrim($package, '/')) {
-          return ['test'];
-        } else {
-          return [];
-        }
+      'entries' => function() {
+        return function($package) {
+          if ('' === rtrim($package, '/')) {
+            return ['test'];
+          } else {
+            return [];
+          }
+        };
       }
     ]);
   }
@@ -52,18 +54,18 @@ class FileBasedTemplateLoaderTest extends \unittest\TestCase {
   #[@test]
   public function templates_in_root() {
     $loader= $this->newFixture(['base']);
-    $this->assertEquals(['test'], $loader->templatesIn());
+    $this->assertEquals(['test'], $loader->listing()->templates());
   }
 
   #[@test, @values([null, '/'])]
   public function templates_in_root_explicitely($root) {
     $loader= $this->newFixture(['base']);
-    $this->assertEquals(['test'], $loader->templatesIn($root));
+    $this->assertEquals(['test'], $loader->listing()->package($root)->templates());
   }
 
   #[@test, @values(['partials', 'partials/'])]
   public function templates_in_package($package) {
     $loader= $this->newFixture(['base']);
-    $this->assertEquals([], $loader->templatesIn($package));
+    $this->assertEquals([], $loader->listing()->package($package)->templates());
   }
 }

--- a/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
@@ -24,6 +24,13 @@ class FileBasedTemplateLoaderTest extends \unittest\TestCase {
           $this->askedFor[]= $name;
           return null;
         }
+      },
+      'templatesIn' => function($package= null) {
+        if ('' === rtrim($package, '/')) {
+          return ['test'];
+        } else {
+          return [];
+        }
       }
     ]);
   }
@@ -40,5 +47,23 @@ class FileBasedTemplateLoaderTest extends \unittest\TestCase {
     $loader= $this->newFixture(['base', ['.mustache', '.ms']]);
     $loader->load('template');
     $this->assertEquals(['template.mustache', 'template.ms'], $loader->askedFor);
+  }
+
+  #[@test]
+  public function templates_in_root() {
+    $loader= $this->newFixture(['base']);
+    $this->assertEquals(['test'], $loader->templatesIn());
+  }
+
+  #[@test, @values([null, '/'])]
+  public function templates_in_root_explicitely($root) {
+    $loader= $this->newFixture(['base']);
+    $this->assertEquals(['test'], $loader->templatesIn($root));
+  }
+
+  #[@test, @values(['partials', 'partials/'])]
+  public function templates_in_package($package) {
+    $loader= $this->newFixture(['base']);
+    $this->assertEquals([], $loader->templatesIn($package));
   }
 }

--- a/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
@@ -55,18 +55,24 @@ class FilesInTest extends \unittest\TestCase {
   #[@test]
   public function templates_in_root() {
     $loader= new FilesIn(self::$temp);
-    $this->assertEquals(['test'], $loader->templatesIn());
+    $this->assertEquals(['test'], $loader->listing()->templates());
   }
 
-  #[@test, @values([null, '/'])]
-  public function templates_in_root_explicitely($root) {
+  #[@test]
+  public function packages_in_root() {
     $loader= new FilesIn(self::$temp);
-    $this->assertEquals(['test'], $loader->templatesIn($root));
+    $this->assertEquals(['partials/'], $loader->listing()->packages());
+  }
+
+  #[@test, @values(['partials', 'partials/'])]
+  public function packages_in_package($package) {
+    $loader= new FilesIn(self::$temp);
+    $this->assertEquals([], $loader->listing()->package($package)->packages());
   }
 
   #[@test, @values(['partials', 'partials/'])]
   public function templates_in_package($package) {
     $loader= new FilesIn(self::$temp);
-    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+    $this->assertEquals(['partials/navigation'], $loader->listing()->package($package)->templates());
   }
 }

--- a/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
@@ -1,0 +1,72 @@
+<?php namespace com\github\mustache\unittest;
+
+use com\github\mustache\FilesIn;
+use com\github\mustache\TemplateNotFoundException;
+use lang\System;
+use io\streams\Streams;
+use io\Folder;
+use io\File;
+use io\FileUtil;
+
+class FilesInTest extends \unittest\TestCase {
+  private static $temp;
+
+  /**
+   * Creates templates in a new temporary directory
+   *
+   * @return void
+   */
+  #[@beforeClass]
+  public static function createFiles() {
+    self::$temp= new Folder(System::tempDir(), uniqid(microtime(true)));
+    self::$temp->create();
+
+    $partials= new Folder(self::$temp, 'partials');
+    $partials->create();
+
+    FileUtil::setContents(new File(self::$temp, 'test.mustache'), 'Mustache template {{id}}');
+    FileUtil::setContents(new File($partials, 'navigation.mustache'), '{{#if nav}}nav{{/if}}');
+  }
+
+  /**
+   * Removes temporary directory
+   *
+   * @return void
+   */
+  #[@afterClass]
+  public static function cleanupFiles() {
+    self::$temp->unlink();
+  }
+
+  #[@test]
+  public function load_from_default_class_loader() {
+    $loader= new FilesIn(self::$temp);
+    $this->assertEquals(
+      'Mustache template {{id}}',
+      Streams::readAll($loader->load('test'))
+    );
+  }
+
+  #[@test, @expect(TemplateNotFoundException::class)]
+  public function load_non_existant() {
+    (new FilesIn(self::$temp))->load('@non.existant@');
+  }
+
+  #[@test]
+  public function templates_in_root() {
+    $loader= new FilesIn(self::$temp);
+    $this->assertEquals(['test'], $loader->templatesIn());
+  }
+
+  #[@test, @values([null, '/'])]
+  public function templates_in_root_explicitely($root) {
+    $loader= new FilesIn(self::$temp);
+    $this->assertEquals(['test'], $loader->templatesIn($root));
+  }
+
+  #[@test, @values(['partials', 'partials/'])]
+  public function templates_in_package($package) {
+    $loader= new FilesIn(self::$temp);
+    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+  }
+}

--- a/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
@@ -21,19 +21,35 @@ class InMemoryTest extends \unittest\TestCase {
   #[@test]
   public function templates_in_root() {
     $loader= new InMemory(['navigation' => 'Test']);
-    $this->assertEquals(['navigation'], $loader->templatesIn());
+    $this->assertEquals(['navigation'], $loader->listing()->templates());
+  }
+
+  #[@test]
+  public function packages_in_packages() {
+    $loader= new InMemory(['partials/navigation' => 'Test']);
+    $this->assertEquals(['partials/'], $loader->listing()->packages());
+  }
+
+  #[@test]
+  public function packages_in_packages_not_fetched_recursively() {
+    $loader= new InMemory([
+      'partials/navigation/header' => 'Header',
+      'partials/navigation/aside'  => 'Aside',
+      'partials/content/main'      => 'Body'
+    ]);
+    $this->assertEquals(['partials/'], $loader->listing()->packages());
   }
 
   #[@test, @values([null, '/'])]
   public function templates_in_root_explicitely($root) {
     $loader= new InMemory(['navigation' => 'Test']);
-    $this->assertEquals(['navigation'], $loader->templatesIn($root));
+    $this->assertEquals(['navigation'], $loader->listing()->package($root)->templates());
   }
 
   #[@test, @values(['partials', 'partials/'])]
   public function templates_in_package($package) {
     $loader= new InMemory(['partials/navigation' => 'Test']);
-    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+    $this->assertEquals(['partials/navigation'], $loader->listing()->package($package)->templates());
   }
 
   #[@test, @values([null, '/'])]
@@ -43,7 +59,7 @@ class InMemoryTest extends \unittest\TestCase {
       'navigation/header' => 'Header',
       'navigation/aside'  => 'Aside'
     ]);
-    $this->assertEquals(['navigation'], $loader->templatesIn($root));
+    $this->assertEquals(['navigation'], $loader->listing()->package($root)->templates());
   }
 
   #[@test, @values(['partials', 'partials/'])]
@@ -53,6 +69,6 @@ class InMemoryTest extends \unittest\TestCase {
       'partials/navigation/header' => 'Header',
       'partials/navigation/aside'  => 'Aside'
     ]);
-    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+    $this->assertEquals(['partials/navigation'], $loader->listing()->package($package)->templates());
   }
 }

--- a/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
@@ -1,0 +1,58 @@
+<?php namespace com\github\mustache\unittest;
+
+use com\github\mustache\InMemory;
+use com\github\mustache\TemplateNotFoundException;
+use io\streams\Streams;
+
+class InMemoryTest extends \unittest\TestCase {
+
+  #[@test]
+  public function load() {
+    $content= 'Mustache template {{id}}';
+    $loader= new InMemory(['test' => $content]);
+    $this->assertEquals($content, Streams::readAll($loader->load('test')));
+  }
+
+  #[@test, @expect(TemplateNotFoundException::class)]
+  public function load_non_existant() {
+    (new InMemory())->load('@non.existant@');
+  }
+
+  #[@test]
+  public function templates_in_root() {
+    $loader= new InMemory(['navigation' => 'Test']);
+    $this->assertEquals(['navigation'], $loader->templatesIn());
+  }
+
+  #[@test, @values([null, '/'])]
+  public function templates_in_root_explicitely($root) {
+    $loader= new InMemory(['navigation' => 'Test']);
+    $this->assertEquals(['navigation'], $loader->templatesIn($root));
+  }
+
+  #[@test, @values(['partials', 'partials/'])]
+  public function templates_in_package($package) {
+    $loader= new InMemory(['partials/navigation' => 'Test']);
+    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+  }
+
+  #[@test, @values([null, '/'])]
+  public function templates_not_fetched_recursively_from_root($root) {
+    $loader= new InMemory([
+      'navigation'        => 'Global',
+      'navigation/header' => 'Header',
+      'navigation/aside'  => 'Aside'
+    ]);
+    $this->assertEquals(['navigation'], $loader->templatesIn($root));
+  }
+
+  #[@test, @values(['partials', 'partials/'])]
+  public function templates_not_fetched_recursively_from_package($package) {
+    $loader= new InMemory([
+      'partials/navigation'        => 'Global',
+      'partials/navigation/header' => 'Header',
+      'partials/navigation/aside'  => 'Aside'
+    ]);
+    $this->assertEquals(['partials/navigation'], $loader->templatesIn($package));
+  }
+}

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -38,4 +38,16 @@ class ResourcesInTest extends \unittest\TestCase {
     $loader= new ResourcesIn(ClassLoader::getDefault());
     $this->assertEquals(['com/github/mustache/unittest/template'], $loader->listing()->package($package)->templates());
   }
+
+  #[@test]
+  public function packages_in_root() {
+    $loader= new ResourcesIn(typeof($this)->getClassLoader());
+    $this->assertEquals(['com/'], $loader->listing()->packages());
+  }
+
+  #[@test, @values(['com/github/mustache', 'com/github/mustache/'])]
+  public function packages_in_package($package) {
+    $loader= new ResourcesIn(typeof($this)->getClassLoader());
+    $this->assertEquals(['com/github/mustache/unittest/'], $loader->listing()->package($package)->packages());
+  }
 }

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace com\github\mustache\unittest;
 
 use com\github\mustache\ResourcesIn;
+use com\github\mustache\TemplateNotFoundException;
 use lang\ClassLoader;
 use io\streams\Streams;
 
@@ -13,5 +14,28 @@ class ResourcesInTest extends \unittest\TestCase {
       'Mustache template {{id}}',
       Streams::readAll($loader->load('com/github/mustache/unittest/template'))
     );
+  }
+
+  #[@test, @expect(TemplateNotFoundException::class)]
+  public function load_non_existant() {
+    (new ResourcesIn(ClassLoader::getDefault()))->load('@non.existant@');
+  }
+
+  #[@test]
+  public function templates_in_root() {
+    $loader= new ResourcesIn(ClassLoader::getDefault());
+    $this->assertEquals([], $loader->templatesIn());
+  }
+
+  #[@test, @values([null, '/'])]
+  public function templates_in_root_explicitely($root) {
+    $loader= new ResourcesIn(ClassLoader::getDefault());
+    $this->assertEquals([], $loader->templatesIn($root));
+  }
+
+  #[@test, @values(['com/github/mustache/unittest', 'com/github/mustache/unittest/'])]
+  public function templates_in_package($package) {
+    $loader= new ResourcesIn(ClassLoader::getDefault());
+    $this->assertEquals(['com/github/mustache/unittest/template'], $loader->templatesIn($package));
   }
 }

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -24,18 +24,18 @@ class ResourcesInTest extends \unittest\TestCase {
   #[@test]
   public function templates_in_root() {
     $loader= new ResourcesIn(ClassLoader::getDefault());
-    $this->assertEquals([], $loader->templatesIn());
+    $this->assertEquals([], $loader->listing()->templates());
   }
 
   #[@test, @values([null, '/'])]
   public function templates_in_root_explicitely($root) {
     $loader= new ResourcesIn(ClassLoader::getDefault());
-    $this->assertEquals([], $loader->templatesIn($root));
+    $this->assertEquals([], $loader->listing()->package($root)->templates());
   }
 
   #[@test, @values(['com/github/mustache/unittest', 'com/github/mustache/unittest/'])]
   public function templates_in_package($package) {
     $loader= new ResourcesIn(ClassLoader::getDefault());
-    $this->assertEquals(['com/github/mustache/unittest/template'], $loader->templatesIn($package));
+    $this->assertEquals(['com/github/mustache/unittest/template'], $loader->listing()->package($package)->templates());
   }
 }


### PR DESCRIPTION
The FilesIn, ResourcesIn and InMemory template loaders implement a new interface, `com.github.mustache.WithListing`, which defines the method `listing()`. This method returns a *TemplateListing* instance.

## API

```php
public class com.github.mustache.TemplateListing {

  /** Returns a list of template names */
  public string[] templates()
 
  /** Returns a list of package names inside this package */
  public string[] packages()

  /** Navigates to a subpackage inside this package */ 
  public com.github.mustache.TemplateListing package(string $name)
}
```

## Example
The following lists all *.mustache* files in the directory *src/main/mustache*, non-recursively, without an extension:

```php
$loader= new FilesIn('src/main/mustache');
foreach ($loader->listing()->templates() as $name) {
  echo 'Have template ', $name, "\n";
}
```
The name could be fed directly into `$engine->load()`, for example.

## Release
By using a new interface instead of extending the old one, this can be kept BC-break free, and the feature would be released as xp-forge/mustache, version **3.1.0**. 