### PR TITLE
Refactor template loading mechanism

### DIFF
--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -50,9 +50,8 @@ abstract class FileBasedTemplateLoader implements Templates {
   /**
    * Load a template by a given name
    *
-   * @param  string $name The template name without file extension
-   * @return io.streams.InputStream
-   * @throws com.github.mustache.TemplateNotFoundException
+   * @param  string $name The template name, not including the file extension
+   * @return com.github.mustache.templates.Source
    */
   public function load($name) {
     $variants= $this->variantsOf($name);

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -3,7 +3,7 @@
 use util\Objects;
 use text\StreamTokenizer;
 use com\github\mustache\templates\Templates;
-use com\github\mustache\templates\Input;
+use com\github\mustache\templates\Tokens;
 use com\github\mustache\templates\NotFound;
 
 /**
@@ -56,7 +56,7 @@ abstract class FileBasedTemplateLoader extends Templates {
   public function source($name) {
     $variants= $this->variantsOf($name);
     foreach ($variants as $variant) {
-      if ($stream= $this->inputStreamFor($variant)) return new Input($variant, new StreamTokenizer($stream));
+      if ($stream= $this->inputStreamFor($variant)) return new Tokens($variant, new StreamTokenizer($stream));
     }
 
     return new NotFound('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -56,7 +56,7 @@ abstract class FileBasedTemplateLoader extends Templates {
   public function source($name) {
     $variants= $this->variantsOf($name);
     foreach ($variants as $variant) {
-      if ($stream= $this->inputStreamFor($variant)) return new Input(new StreamTokenizer($stream));
+      if ($stream= $this->inputStreamFor($variant)) return new Input($variant, new StreamTokenizer($stream));
     }
 
     return new NotFound('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -1,13 +1,17 @@
 <?php namespace com\github\mustache;
 
 use util\Objects;
+use text\StreamTokenizer;
+use com\github\mustache\templates\Templates;
+use com\github\mustache\templates\Source;
+use com\github\mustache\templates\NotFound;
 
 /**
  * File-based template loading loads templates from the file system.
  *
  * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
  */
-abstract class FileBasedTemplateLoader implements TemplateLoader, WithListing {
+abstract class FileBasedTemplateLoader implements Templates, WithListing {
   protected $base, $extensions, $listing;
 
   /**
@@ -53,9 +57,10 @@ abstract class FileBasedTemplateLoader implements TemplateLoader, WithListing {
   public function load($name) {
     $variants= $this->variantsOf($name);
     foreach ($variants as $variant) {
-      if ($stream= $this->inputStreamFor($variant)) return $stream;
+      if ($stream= $this->inputStreamFor($variant)) return new Source(new StreamTokenizer($stream));
     }
-    throw new TemplateNotFoundException('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));
+
+    return new NotFound('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));
   }
 
   /**

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -11,7 +11,7 @@ use com\github\mustache\templates\NotFound;
  *
  * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
  */
-abstract class FileBasedTemplateLoader implements Templates, WithListing {
+abstract class FileBasedTemplateLoader implements Templates {
   protected $base, $extensions, $listing;
 
   /**

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -3,7 +3,7 @@
 use util\Objects;
 use text\StreamTokenizer;
 use com\github\mustache\templates\Templates;
-use com\github\mustache\templates\Source;
+use com\github\mustache\templates\Input;
 use com\github\mustache\templates\NotFound;
 
 /**
@@ -11,7 +11,7 @@ use com\github\mustache\templates\NotFound;
  *
  * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
  */
-abstract class FileBasedTemplateLoader implements Templates {
+abstract class FileBasedTemplateLoader extends Templates {
   protected $base, $extensions, $listing;
 
   /**
@@ -53,10 +53,10 @@ abstract class FileBasedTemplateLoader implements Templates {
    * @param  string $name The template name, not including the file extension
    * @return com.github.mustache.templates.Source
    */
-  public function load($name) {
+  public function source($name) {
     $variants= $this->variantsOf($name);
     foreach ($variants as $variant) {
-      if ($stream= $this->inputStreamFor($variant)) return new Source(new StreamTokenizer($stream));
+      if ($stream= $this->inputStreamFor($variant)) return new Input(new StreamTokenizer($stream));
     }
 
     return new NotFound('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -2,7 +2,7 @@
 
 use text\StringTokenizer;
 use com\github\mustache\templates\Templates;
-use com\github\mustache\templates\Source;
+use com\github\mustache\templates\Input;
 use com\github\mustache\templates\NotFound;
 
 /**
@@ -10,7 +10,7 @@ use com\github\mustache\templates\NotFound;
  *
  * @test  xp://com.github.mustache.unittest.InMemoryTest
  */
-class InMemory implements Templates {
+class InMemory extends Templates {
   protected $templates, $listing;
 
   /**
@@ -61,11 +61,11 @@ class InMemory implements Templates {
    * Load a template by a given name
    *
    * @param  string $name The template name, not including the file extension
-   * @return com.github.mustache.TemplateSource
+   * @return com.github.mustache.templates.Source
    */
-  public function load($name) {
+  public function source($name) {
     if (isset($this->templates[$name])) {
-      return new Source(new StringTokenizer($this->templates[$name]));
+      return new Input(new StringTokenizer($this->templates[$name]));
     } else {
       return new NotFound('Cannot find template '.$name);
     }

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -1,13 +1,16 @@
 <?php namespace com\github\mustache;
 
-use io\streams\MemoryInputStream;
+use text\StringTokenizer;
+use com\github\mustache\templates\Templates;
+use com\github\mustache\templates\Source;
+use com\github\mustache\templates\NotFound;
 
 /**
  * Template loading
  *
  * @test  xp://com.github.mustache.unittest.InMemoryTest
  */
-class InMemory implements TemplateLoader, WithListing {
+class InMemory implements Templates, WithListing {
   protected $templates, $listing;
 
   /**
@@ -54,18 +57,18 @@ class InMemory implements TemplateLoader, WithListing {
     return $this;
   }
 
-	/**
-	 * Load a template by a given name
-	 *
-	 * @param  string $name The template name without file extension
-	 * @return io.streams.InputStream
-	 * @throws com.github.mustache.TemplateNotFoundException
-	 */
+  /**
+   * Load a template by a given name
+   *
+   * @param  string $name The template name, not including the file extension
+   * @return com.github.mustache.TemplateSource
+   */
   public function load($name) {
     if (isset($this->templates[$name])) {
-      return new MemoryInputStream($this->templates[$name]);
+      return new Source(new StringTokenizer($this->templates[$name]));
+    } else {
+      return new NotFound('Cannot find template undefined '.$name);
     }
-    throw new TemplateNotFoundException('Cannot find template '.$name);
   }
 
   /**

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -2,8 +2,8 @@
 
 use text\StringTokenizer;
 use com\github\mustache\templates\Templates;
-use com\github\mustache\templates\Input;
 use com\github\mustache\templates\NotFound;
+use com\github\mustache\templates\Tokens;
 
 /**
  * Template loading
@@ -65,7 +65,7 @@ class InMemory extends Templates {
    */
   public function source($name) {
     if (isset($this->templates[$name])) {
-      return new Input($name, new StringTokenizer($this->templates[$name]));
+      return new Tokens($name, new StringTokenizer($this->templates[$name]));
     } else {
       return new NotFound('Cannot find template '.$name);
     }

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -65,7 +65,7 @@ class InMemory extends Templates {
    */
   public function source($name) {
     if (isset($this->templates[$name])) {
-      return new Input(new StringTokenizer($this->templates[$name]));
+      return new Input($name, new StringTokenizer($this->templates[$name]));
     } else {
       return new NotFound('Cannot find template '.$name);
     }

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -67,7 +67,7 @@ class InMemory implements Templates, WithListing {
     if (isset($this->templates[$name])) {
       return new Source(new StringTokenizer($this->templates[$name]));
     } else {
-      return new NotFound('Cannot find template undefined '.$name);
+      return new NotFound('Cannot find template '.$name);
     }
   }
 

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -10,7 +10,7 @@ use com\github\mustache\templates\NotFound;
  *
  * @test  xp://com.github.mustache.unittest.InMemoryTest
  */
-class InMemory implements Templates, WithListing {
+class InMemory implements Templates {
   protected $templates, $listing;
 
   /**

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -95,7 +95,7 @@ class MustacheEngine {
   }
 
   /**
-   * Compile a template.
+   * Compile a template
    *
    * @param  string|com.github.mustache.templates.Input $template The template
    * @param  string $start Initial start tag, defaults to "{{"
@@ -113,7 +113,7 @@ class MustacheEngine {
   }
 
   /**
-   * Load a template.
+   * Load and compile a template
    *
    * @param  string $name The template name.
    * @param  string $start Initial start tag, defaults to "{{"
@@ -143,7 +143,7 @@ class MustacheEngine {
     } else {
       $c= new DataContext($context);
     }
-    return $template->evaluate($c->withEngine($this));
+    return $template->evaluate($context->withEngine($this));
   }
 
   /**
@@ -157,10 +157,7 @@ class MustacheEngine {
    * @return string The rendered output
    */
   public function render($template, $arg, $start= '{{', $end= '}}', $indent= '') {
-    return $this->evaluate(
-      $this->compile($template, $start, $end, $indent),
-      $arg
-    );
+    return $this->evaluate($this->compile($template, $start, $end, $indent), $arg);
   }
 
   /**
@@ -175,9 +172,6 @@ class MustacheEngine {
    * @return string The rendered output
    */
   public function transform($name, $arg, $start= '{{', $end= '}}', $indent= '') {
-    return $this->evaluate(
-      $this->load($name, $start, $end, $indent),
-      $arg
-    );
+    return $this->evaluate($this->load($name, $start, $end, $indent), $arg);
   }
 }

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\github\mustache;
 
-use com\github\mustache\templates\Input;
+use com\github\mustache\templates\Source;
 use com\github\mustache\templates\Templates;
 use com\github\mustache\templates\FromLoader;
 use text\StringTokenizer;
@@ -97,7 +97,7 @@ class MustacheEngine {
   /**
    * Compile a template
    *
-   * @param  string|com.github.mustache.templates.Input $template The template
+   * @param  string|com.github.mustache.templates.Source $template The template
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
@@ -105,7 +105,7 @@ class MustacheEngine {
    */
   public function compile($template, $start= '{{', $end= '}}', $indent= '') {
     return new Template('<string>', $this->parser->parse(
-      $template instanceof Input ? $template->tokens() : new StringTokenizer($template),
+      $template instanceof Source ? $template->tokens() : new StringTokenizer($template),
       $start,
       $end,
       $indent
@@ -123,7 +123,7 @@ class MustacheEngine {
    */
   public function load($name, $start= '{{', $end= '}}', $indent= '') {
     return new Template($name, $this->parser->parse(
-      $this->templates->load($name)->tokens(),
+      $this->templates->source($name)->tokens(),
       $start,
       $end,
       $indent
@@ -149,7 +149,7 @@ class MustacheEngine {
   /**
    * Render a template, compiling it from source
    *
-   * @param  string|com.github.mustache.templates.Input $template
+   * @param  string|com.github.mustache.templates.Source $template
    * @param  com.github.mustache.Context|[:var] $context The context
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -104,12 +104,11 @@ class MustacheEngine {
    * @return com.github.mustache.Template
    */
   public function compile($template, $start= '{{', $end= '}}', $indent= '') {
-    return new Template('<string>', $this->parser->parse(
-      $template instanceof Source ? $template->tokens() : new StringTokenizer($template),
-      $start,
-      $end,
-      $indent
-    ));
+    if ($template instanceof Source) {
+      return $template->compile($this->parser, $start, $end, $indent);
+    } else {
+      return new Template('<string>', $this->parser->parse(new StringTokenizer($template), $start, $end, $indent));
+    }
   }
 
   /**
@@ -122,12 +121,7 @@ class MustacheEngine {
    * @return com.github.mustache.Template
    */
   public function load($name, $start= '{{', $end= '}}', $indent= '') {
-    return new Template($name, $this->parser->parse(
-      $this->templates->source($name)->tokens(),
-      $start,
-      $end,
-      $indent
-    ));
+    return $this->templates->source($name)->compile($this->parser, $start, $end, $indent);
   }
 
   /**

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -134,16 +134,16 @@ class MustacheEngine {
    * Evaluate a compiled template.
    *
    * @param  com.github.mustache.Template $template The template
-   * @param  var $arg Either a view context, or a Context instance
+   * @param  com.github.mustache.Context|[:var] $context The context
    * @return string The rendered output
    */
-  public function evaluate(Template $template, $arg) {
-    if ($arg instanceof Context) {
-      $context= $arg;
+  public function evaluate(Template $template, $context) {
+    if ($context instanceof Context) {
+      $c= $context;
     } else {
-      $context= new DataContext($arg);
+      $c= new DataContext($context);
     }
-    return $template->evaluate($context->withEngine($this));
+    return $template->evaluate($c->withEngine($this));
   }
 
   /**

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -97,17 +97,17 @@ class MustacheEngine {
   /**
    * Compile a template
    *
-   * @param  string|com.github.mustache.templates.Source $template The template
+   * @param  string|com.github.mustache.templates.Source $source The template source
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
    * @return com.github.mustache.Template
    */
-  public function compile($template, $start= '{{', $end= '}}', $indent= '') {
-    if ($template instanceof Source) {
-      return $template->compile($this->parser, $start, $end, $indent);
+  public function compile($source, $start= '{{', $end= '}}', $indent= '') {
+    if ($source instanceof Source) {
+      return $source->compile($this->parser, $start, $end, $indent);
     } else {
-      return new Template('<string>', $this->parser->parse(new StringTokenizer($template), $start, $end, $indent));
+      return new Template('<string>', $this->parser->parse(new StringTokenizer($source), $start, $end, $indent));
     }
   }
 
@@ -143,15 +143,15 @@ class MustacheEngine {
   /**
    * Render a template, compiling it from source
    *
-   * @param  string|com.github.mustache.templates.Source $template
+   * @param  string|com.github.mustache.templates.Source $source The template source
    * @param  com.github.mustache.Context|[:var] $context The context
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
    * @return string The rendered output
    */
-  public function render($template, $context, $start= '{{', $end= '}}', $indent= '') {
-    return $this->evaluate($this->compile($template, $start, $end, $indent), $context);
+  public function render($source, $context, $start= '{{', $end= '}}', $indent= '') {
+    return $this->evaluate($this->compile($source, $start, $end, $indent), $context);
   }
 
   /**

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\github\mustache;
 
-use com\github\mustache\templates\Source;
+use com\github\mustache\templates\Input;
 use com\github\mustache\templates\Templates;
 use com\github\mustache\templates\FromLoader;
 use text\StringTokenizer;
@@ -97,7 +97,7 @@ class MustacheEngine {
   /**
    * Compile a template.
    *
-   * @param  string|com.github.mustache.templates.Source $template The template
+   * @param  string|com.github.mustache.templates.Input $template The template
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
@@ -105,7 +105,7 @@ class MustacheEngine {
    */
   public function compile($template, $start= '{{', $end= '}}', $indent= '') {
     return new Template('<string>', $this->parser->parse(
-      $template instanceof Source ? $template->tokens() : new StringTokenizer($template),
+      $template instanceof Input ? $template->tokens() : new StringTokenizer($template),
       $start,
       $end,
       $indent
@@ -149,7 +149,7 @@ class MustacheEngine {
   /**
    * Render a template, compiling it from source
    *
-   * @param  string|com.github.mustache.templates.Source $template
+   * @param  string|com.github.mustache.templates.Input $template
    * @param  var $arg Either a view context, or a Context instance
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -150,14 +150,14 @@ class MustacheEngine {
    * Render a template, compiling it from source
    *
    * @param  string|com.github.mustache.templates.Input $template
-   * @param  var $arg Either a view context, or a Context instance
+   * @param  com.github.mustache.Context|[:var] $context The context
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
    * @return string The rendered output
    */
-  public function render($template, $arg, $start= '{{', $end= '}}', $indent= '') {
-    return $this->evaluate($this->compile($template, $start, $end, $indent), $arg);
+  public function render($template, $context, $start= '{{', $end= '}}', $indent= '') {
+    return $this->evaluate($this->compile($template, $start, $end, $indent), $context);
   }
 
   /**
@@ -165,13 +165,13 @@ class MustacheEngine {
    * the template loader.
    *
    * @param  string $name The template name.
-   * @param  var $arg Either a view context, or a Context instance
+   * @param  com.github.mustache.Context|[:var] $context The context
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent Indenting level, defaults to no indenting
    * @return string The rendered output
    */
-  public function transform($name, $arg, $start= '{{', $end= '}}', $indent= '') {
-    return $this->evaluate($this->load($name, $start, $end, $indent), $arg);
+  public function transform($name, $context, $start= '{{', $end= '}}', $indent= '') {
+    return $this->evaluate($this->load($name, $start, $end, $indent), $context);
   }
 }

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -39,7 +39,7 @@ class MustacheEngine {
   /**
    * Sets template loader to be used
    *
-   * @param  com.github.mustache.Templates|com.github.mustache.TemplateLoader $l
+   * @param  com.github.mustache.templates.Templates|com.github.mustache.TemplateLoader $l
    * @return self this
    */
   public function withTemplates($l) {

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -143,7 +143,7 @@ class MustacheEngine {
     } else {
       $c= new DataContext($context);
     }
-    return $template->evaluate($context->withEngine($this));
+    return $template->evaluate($c->withEngine($this));
   }
 
   /**

--- a/src/main/php/com/github/mustache/TemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/TemplateLoader.class.php
@@ -3,6 +3,7 @@
 /**
  * Template loading
  *
+ * @deprecated Use com.github.mustache.templates.Templates instead!
  * @test xp://com.github.mustache.unittest.TemplateTransformationTest
  */
 interface TemplateLoader {

--- a/src/main/php/com/github/mustache/WithListing.class.php
+++ b/src/main/php/com/github/mustache/WithListing.class.php
@@ -2,6 +2,8 @@
 
 /**
  * Template listing
+ *
+ * @deprecated Use com.github.mustache.templates.Templates instead!
  */
 interface WithListing {
 

--- a/src/main/php/com/github/mustache/templates/Compiled.class.php
+++ b/src/main/php/com/github/mustache/templates/Compiled.class.php
@@ -8,9 +8,6 @@ class Compiled extends Source {
     $this->template= $template;
   }
 
-  /** @return bool */
-  public function exists() { return true; }
-
   /** @return string */
   public function code() { return (string)$this->template; }
 

--- a/src/main/php/com/github/mustache/templates/Compiled.class.php
+++ b/src/main/php/com/github/mustache/templates/Compiled.class.php
@@ -1,22 +1,18 @@
 <?php namespace com\github\mustache\templates;
 
-use com\github\mustache\TemplateNotFoundException;
+class Compiled extends Source {
+  private $tokens;
 
-class NotFound extends Source {
-  private $reason;
-
-  /** @param string $reason */
-  public function __construct($reason) {
-    $this->reason= $reason;
+  /** @param com.github.mustache.Template */
+  public function __construct($template) {
+    $this->template= $template;
   }
 
   /** @return bool */
-  public function exists() { return false; }
+  public function exists() { return true; }
 
   /** @return string */
-  public function code() {
-    throw new TemplateNotFoundException($this->reason);
-  }
+  public function code() { return (string)$this->template; }
 
   /**
    * Compiles this input into a template
@@ -28,6 +24,6 @@ class NotFound extends Source {
    * @return com.github.mustache.Template
    */
   public function compile($parser, $start, $end, $indent) {
-    throw new TemplateNotFoundException($this->reason);
+    return $this->template;
   }
 }

--- a/src/main/php/com/github/mustache/templates/Compiled.class.php
+++ b/src/main/php/com/github/mustache/templates/Compiled.class.php
@@ -12,7 +12,7 @@ class Compiled extends Source {
   public function code() { return (string)$this->template; }
 
   /**
-   * Compiles this input into a template
+   * Compiles this source into a template
    *
    * @param  com.github.mustache.MustacheParser $parser
    * @param  string $start

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -25,7 +25,7 @@ class FromLoader extends Templates {
    */
   public function source($name) {
     try {
-      return new Input(new StreamTokenizer($this->loader->load($name)));
+      return new Input($name, new StreamTokenizer($this->loader->load($name)));
     } catch (TemplateNotFoundException $e) {
       return new NotFound($e->getMessage());
     }

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -1,0 +1,31 @@
+<?php namespace com\github\mustache\templates;
+
+use text\StreamTokenizer;
+
+/**
+ * Adapter for TemplateLoaders
+ *
+ * @deprecated Template loaders were replaced by `Templates`.
+ */
+class FromLoader implements Templates {
+  private $loader;
+
+  /** @param com.github.mustache.TemplateLoader $loader */
+  public function __construct($loader) {
+    $this->loader= $loader;
+  }
+
+  /**
+   * Load a template by a given name
+   *
+   * @param  string $name The template name, not including the file extension
+   * @return com.github.mustache.TemplateSource
+   */
+  public function load($name) {
+    try {
+      return new Source(new StreamTokenizer($this->loader->load($name)));
+    } catch (TemplateNotFoundException $e) {
+      return new NotFound($e->getMessage());
+    }
+  }
+}

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -1,6 +1,7 @@
 <?php namespace com\github\mustache\templates;
 
 use text\StreamTokenizer;
+use lang\IllegalAccessException;
 
 /**
  * Adapter for TemplateLoaders
@@ -26,6 +27,19 @@ class FromLoader implements Templates {
       return new Source(new StreamTokenizer($this->loader->load($name)));
     } catch (TemplateNotFoundException $e) {
       return new NotFound($e->getMessage());
+    }
+  }
+
+  /**
+   * Returns available templates
+   *
+   * @return  com.github.mustache.TemplateListing
+   */
+  public function listing() {
+    if ($this->loader instanceof WithListing) {
+      return $this->loader->listing();
+    } else {
+      throw new IllegalAccessException(typeof($this->loader)->toString().' does not provide listing');
     }
   }
 }

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -9,7 +9,7 @@ use com\github\mustache\WithListing;
  *
  * @deprecated Template loaders were replaced by `Templates`.
  */
-class FromLoader implements Templates {
+class FromLoader extends Templates {
   private $loader;
 
   /** @param com.github.mustache.TemplateLoader $loader */
@@ -23,9 +23,9 @@ class FromLoader implements Templates {
    * @param  string $name The template name, not including the file extension
    * @return com.github.mustache.TemplateSource
    */
-  public function load($name) {
+  public function source($name) {
     try {
-      return new Source(new StreamTokenizer($this->loader->load($name)));
+      return new Input(new StreamTokenizer($this->loader->load($name)));
     } catch (TemplateNotFoundException $e) {
       return new NotFound($e->getMessage());
     }

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -3,6 +3,7 @@
 use text\StreamTokenizer;
 use lang\IllegalAccessException;
 use com\github\mustache\WithListing;
+use com\github\mustache\templates\Tokens;
 
 /**
  * Adapter for TemplateLoaders
@@ -25,7 +26,7 @@ class FromLoader extends Templates {
    */
   public function source($name) {
     try {
-      return new Input($name, new StreamTokenizer($this->loader->load($name)));
+      return new Tokens($name, new StreamTokenizer($this->loader->load($name)));
     } catch (TemplateNotFoundException $e) {
       return new NotFound($e->getMessage());
     }

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -2,6 +2,7 @@
 
 use text\StreamTokenizer;
 use lang\IllegalAccessException;
+use com\github\mustache\WithListing;
 
 /**
  * Adapter for TemplateLoaders

--- a/src/main/php/com/github/mustache/templates/Input.class.php
+++ b/src/main/php/com/github/mustache/templates/Input.class.php
@@ -1,9 +1,15 @@
 <?php namespace com\github\mustache\templates;
 
-interface Input {
+class Input implements Source {
+  private $tokens;
+
+  /** @param  text.Tokenizer $tokens */
+  public function __construct($tokens) {
+    $this->tokens= $tokens;
+  }
 
   /** @return bool */
-  public function exists();
+  public function exists() { return true; }
 
   /**
    * Returns tokens
@@ -11,5 +17,5 @@ interface Input {
    * @return text.Tokenizer
    * @throws com.github.mustache.TemplateNotFoundException
    */
-  public function tokens();
+  public function tokens() { return $this->tokens; }
 }

--- a/src/main/php/com/github/mustache/templates/Input.class.php
+++ b/src/main/php/com/github/mustache/templates/Input.class.php
@@ -26,7 +26,7 @@ class Input extends Source {
   }
 
   /**
-   * Compiles this input into a template
+   * Compiles this source into a template
    *
    * @param  com.github.mustache.MustacheParser $parser
    * @param  string $start

--- a/src/main/php/com/github/mustache/templates/Input.class.php
+++ b/src/main/php/com/github/mustache/templates/Input.class.php
@@ -1,0 +1,15 @@
+<?php namespace com\github\mustache\templates;
+
+interface Input {
+
+  /** @return bool */
+  public function exists();
+
+  /**
+   * Returns tokens
+   *
+   * @return text.Tokenizer
+   * @throws com.github.mustache.TemplateNotFoundException
+   */
+  public function tokens();
+}

--- a/src/main/php/com/github/mustache/templates/Input.class.php
+++ b/src/main/php/com/github/mustache/templates/Input.class.php
@@ -1,21 +1,43 @@
 <?php namespace com\github\mustache\templates;
 
-class Input implements Source {
-  private $tokens;
+use com\github\mustache\Template;
 
-  /** @param  text.Tokenizer $tokens */
-  public function __construct($tokens) {
+class Input extends Source {
+  private $source, $tokens;
+
+  /**
+   * Creates a new input
+   *
+   * @param  string $source
+   * @param  text.Tokenizer $tokens
+   */
+  public function __construct($source, $tokens) {
+    $this->source= $source;
     $this->tokens= $tokens;
   }
 
   /** @return bool */
   public function exists() { return true; }
 
+  /** @return string */
+  public function code() {
+    $s= '';
+    while ($this->tokens->hasMoreTokens()) {
+      $s.= $this->tokens->nextToken(true);
+    }
+    return $s;
+  }
+
   /**
-   * Returns tokens
+   * Compiles this input into a template
    *
-   * @return text.Tokenizer
-   * @throws com.github.mustache.TemplateNotFoundException
+   * @param  com.github.mustache.MustacheParser $parser
+   * @param  string $start
+   * @param  string $end
+   * @param  string $indent
+   * @return com.github.mustache.Template
    */
-  public function tokens() { return $this->tokens; }
+  public function compile($parser, $start, $end, $indent) {
+    return new Template($this->source, $parser->parse($this->tokens, $start, $end, $indent));
+  }
 }

--- a/src/main/php/com/github/mustache/templates/Input.class.php
+++ b/src/main/php/com/github/mustache/templates/Input.class.php
@@ -16,9 +16,6 @@ class Input extends Source {
     $this->tokens= $tokens;
   }
 
-  /** @return bool */
-  public function exists() { return true; }
-
   /** @return string */
   public function code() {
     $s= '';

--- a/src/main/php/com/github/mustache/templates/NotFound.class.php
+++ b/src/main/php/com/github/mustache/templates/NotFound.class.php
@@ -19,7 +19,7 @@ class NotFound extends Source {
   }
 
   /**
-   * Compiles this input into a template
+   * Compiles this source into a template
    *
    * @param  com.github.mustache.MustacheParser $parser
    * @param  string $start

--- a/src/main/php/com/github/mustache/templates/NotFound.class.php
+++ b/src/main/php/com/github/mustache/templates/NotFound.class.php
@@ -2,7 +2,7 @@
 
 use com\github\mustache\TemplateNotFoundException;
 
-class NotFound implements Input {
+class NotFound implements Source {
   private $reason;
 
   /** @param string $reason */

--- a/src/main/php/com/github/mustache/templates/NotFound.class.php
+++ b/src/main/php/com/github/mustache/templates/NotFound.class.php
@@ -1,0 +1,23 @@
+<?php namespace com\github\mustache\templates;
+
+use com\github\mustache\TemplateNotFoundException;
+
+class NotFound implements Input {
+  private $reason;
+
+  /** @param string $reason */
+  public function __construct($reason) {
+    $this->reason= $reason;
+  }
+
+  /** @return bool */
+  public function exists() { return false; }
+
+  /**
+   * Returns tokens
+   *
+   * @return text.Tokenizer
+   * @throws com.github.mustache.TemplateNotFoundException
+   */
+  public function tokens() { throw new TemplateNotFoundException($this->reason); }
+}

--- a/src/main/php/com/github/mustache/templates/Source.class.php
+++ b/src/main/php/com/github/mustache/templates/Source.class.php
@@ -1,15 +1,21 @@
 <?php namespace com\github\mustache\templates;
 
-interface Source {
+abstract class Source {
 
   /** @return bool */
-  public function exists();
+  public abstract function exists();
+
+  /** @return string */
+  public abstract function code();
 
   /**
-   * Returns tokens
+   * Compiles this input into a template
    *
-   * @return text.Tokenizer
-   * @throws com.github.mustache.TemplateNotFoundException
+   * @param  com.github.mustache.MustacheParser $parser
+   * @param  string $start
+   * @param  string $end
+   * @param  string $indent
+   * @return com.github.mustache.Node
    */
-  public function tokens();
+  public abstract function compile($parser, $start, $end, $indent);
 }

--- a/src/main/php/com/github/mustache/templates/Source.class.php
+++ b/src/main/php/com/github/mustache/templates/Source.class.php
@@ -1,15 +1,9 @@
 <?php namespace com\github\mustache\templates;
 
-class Source implements Input {
-  private $tokens;
-
-  /** @param  text.Tokenizer $tokens */
-  public function __construct($tokens) {
-    $this->tokens= $tokens;
-  }
+interface Source {
 
   /** @return bool */
-  public function exists() { return true; }
+  public function exists();
 
   /**
    * Returns tokens
@@ -17,5 +11,5 @@ class Source implements Input {
    * @return text.Tokenizer
    * @throws com.github.mustache.TemplateNotFoundException
    */
-  public function tokens() { return $this->tokens; }
+  public function tokens();
 }

--- a/src/main/php/com/github/mustache/templates/Source.class.php
+++ b/src/main/php/com/github/mustache/templates/Source.class.php
@@ -9,7 +9,7 @@ abstract class Source {
   public abstract function code();
 
   /**
-   * Compiles this input into a template
+   * Compiles this source into a template
    *
    * @param  com.github.mustache.MustacheParser $parser
    * @param  string $start

--- a/src/main/php/com/github/mustache/templates/Source.class.php
+++ b/src/main/php/com/github/mustache/templates/Source.class.php
@@ -3,7 +3,7 @@
 abstract class Source {
 
   /** @return bool */
-  public abstract function exists();
+  public function exists() { return true; }
 
   /** @return string */
   public abstract function code();

--- a/src/main/php/com/github/mustache/templates/Source.class.php
+++ b/src/main/php/com/github/mustache/templates/Source.class.php
@@ -1,0 +1,21 @@
+<?php namespace com\github\mustache\templates;
+
+class Source implements Input {
+  private $tokens;
+
+  /** @param  text.Tokenizer $tokens */
+  public function __construct($tokens) {
+    $this->tokens= $tokens;
+  }
+
+  /** @return bool */
+  public function exists() { return true; }
+
+  /**
+   * Returns tokens
+   *
+   * @return text.Tokenizer
+   * @throws com.github.mustache.TemplateNotFoundException
+   */
+  public function tokens() { return $this->tokens; }
+}

--- a/src/main/php/com/github/mustache/templates/Templates.class.php
+++ b/src/main/php/com/github/mustache/templates/Templates.class.php
@@ -1,24 +1,53 @@
 <?php namespace com\github\mustache\templates;
 
+use com\github\mustache\TemplateLoader;
+use com\github\mustache\WithListing;
+use com\github\mustache\TemplateNotFoundException;
+
 /**
  * Template loading
  *
- * @test xp://com.github.mustache.unittest.TemplateTransformationTest
+ * @test  xp://com.github.mustache.unittest.InMemoryTest
+ * @test  xp://com.github.mustache.unittest.FileBasedTemplateLoaderTest
+ * @test  xp://com.github.mustache.unittest.DeprecatedLoaderFunctionalityTest
  */
-interface Templates {
+abstract class Templates implements TemplateLoader, WithListing {
 
   /**
    * Load a template by a given name
    *
    * @param  string $name The template name, not including the file extension
-   * @return com.github.mustache.templates.Source
+   * @return com.github.mustache.templates.Input
    */
-  public function load($name);
+  public abstract function source($name);
 
   /**
    * Returns available templates
    *
-   * @return  com.github.mustache.TemplateListing
+   * @return com.github.mustache.TemplateListing
    */
-  public function listing();
+  public abstract function listing();
+
+  /**
+   * Load a template by a given name
+   *
+   * @deprecated
+   * @param  string $name The template name, not including the ".mustache" extension
+   * @return io.streams.InputStream
+   * @throws com.github.mustache.TemplateNotFoundException
+   */
+  public function load($name) {
+    $input= $this->source($name);
+    if ($input->exists()) {
+      return newinstance('io.streams.InputStream', [$input->tokens()], [
+        'tokens'      => null,
+        '__construct' => function($tokens) { $this->tokens= $tokens; $this->tokens->delimiter= "\n"; },
+        'available'   => function() { return $this->tokens->hasMoreTokens(); },
+        'read'        => function($bytes= 8192) { return $this->tokens->nextToken(true); },
+        'close'       => function() { }
+      ]);
+    } else {
+      throw new TemplateNotFoundException('Cannot find template '.$name);
+    }
+  }
 }

--- a/src/main/php/com/github/mustache/templates/Templates.class.php
+++ b/src/main/php/com/github/mustache/templates/Templates.class.php
@@ -31,7 +31,7 @@ abstract class Templates implements TemplateLoader, WithListing {
   /**
    * Load a template by a given name
    *
-   * @deprecated
+   * @deprecated Use source() instead
    * @param  string $name The template name, not including the ".mustache" extension
    * @return io.streams.InputStream
    * @throws com.github.mustache.TemplateNotFoundException

--- a/src/main/php/com/github/mustache/templates/Templates.class.php
+++ b/src/main/php/com/github/mustache/templates/Templates.class.php
@@ -2,7 +2,7 @@
 
 use com\github\mustache\TemplateLoader;
 use com\github\mustache\WithListing;
-use com\github\mustache\TemplateNotFoundException;
+use io\streams\MemoryInputStream;
 
 /**
  * Template loading
@@ -37,17 +37,6 @@ abstract class Templates implements TemplateLoader, WithListing {
    * @throws com.github.mustache.TemplateNotFoundException
    */
   public function load($name) {
-    $input= $this->source($name);
-    if ($input->exists()) {
-      return newinstance('io.streams.InputStream', [$input->tokens()], [
-        'tokens'      => null,
-        '__construct' => function($tokens) { $this->tokens= $tokens; $this->tokens->delimiter= "\n"; },
-        'available'   => function() { return $this->tokens->hasMoreTokens(); },
-        'read'        => function($bytes= 8192) { return $this->tokens->nextToken(true); },
-        'close'       => function() { }
-      ]);
-    } else {
-      throw new TemplateNotFoundException('Cannot find template '.$name);
-    }
+    return new MemoryInputStream($this->source($name)->code());
   }
 }

--- a/src/main/php/com/github/mustache/templates/Templates.class.php
+++ b/src/main/php/com/github/mustache/templates/Templates.class.php
@@ -1,0 +1,18 @@
+<?php namespace com\github\mustache\templates;
+
+/**
+ * Template loading
+ *
+ * @test xp://com.github.mustache.unittest.TemplateTransformationTest
+ */
+interface Templates {
+
+  /**
+   * Load a template by a given name
+   *
+   * @param  string $name The template name, not including the file extension
+   * @return com.github.mustache.templates.Source
+   */
+  public function load($name);
+
+}

--- a/src/main/php/com/github/mustache/templates/Templates.class.php
+++ b/src/main/php/com/github/mustache/templates/Templates.class.php
@@ -15,4 +15,10 @@ interface Templates {
    */
   public function load($name);
 
+  /**
+   * Returns available templates
+   *
+   * @return  com.github.mustache.TemplateListing
+   */
+  public function listing();
 }

--- a/src/main/php/com/github/mustache/templates/Tokens.class.php
+++ b/src/main/php/com/github/mustache/templates/Tokens.class.php
@@ -2,11 +2,11 @@
 
 use com\github\mustache\Template;
 
-class Input extends Source {
+class Tokens extends Source {
   private $source, $tokens;
 
   /**
-   * Creates a new input
+   * Creates a new token source
    *
    * @param  string $source
    * @param  text.Tokenizer $tokens

--- a/src/test/php/com/github/mustache/unittest/DeprecatedLoaderFunctionalityTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/DeprecatedLoaderFunctionalityTest.class.php
@@ -1,0 +1,20 @@
+<?php namespace com\github\mustache\unittest;
+
+use com\github\mustache\InMemory;
+use com\github\mustache\TemplateNotFoundException;
+use io\streams\Streams;
+
+class DeprecatedLoaderFunctionalityTest extends \unittest\TestCase {
+
+  #[@test]
+  public function load_returns_stream() {
+    $content= 'Mustache template {{id}}';
+    $loader= new InMemory(['test' => $content]);
+    $this->assertEquals($content, Streams::readAll($loader->load('test')));
+  }
+
+  #[@test, @expect(class= TemplateNotFoundException::class, withMessage= 'Cannot find template not-found')]
+  public function load_raises_error_for_nonexistant_templates() {
+    (new InMemory())->load('not-found');
+  }
+}

--- a/src/test/php/com/github/mustache/unittest/DeprecatedLoaderFunctionalityTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/DeprecatedLoaderFunctionalityTest.class.php
@@ -4,6 +4,7 @@ use com\github\mustache\InMemory;
 use com\github\mustache\TemplateNotFoundException;
 use io\streams\Streams;
 
+/** @deprecated */
 class DeprecatedLoaderFunctionalityTest extends \unittest\TestCase {
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FileBasedTemplateLoaderTest.class.php
@@ -40,14 +40,14 @@ class FileBasedTemplateLoaderTest extends \unittest\TestCase {
   #[@test]
   public function load_asks_for_mustache_extension_by_default() {
     $loader= $this->newFixture(['base']);
-    $loader->load('template');
+    $loader->source('template');
     $this->assertEquals(['template.mustache'], $loader->askedFor);
   }
 
   #[@test]
   public function load_asks_for_all_given_variants() {
     $loader= $this->newFixture(['base', ['.mustache', '.ms']]);
-    $loader->load('template');
+    $loader->source('template');
     $this->assertEquals(['template.mustache', 'template.ms'], $loader->askedFor);
   }
 

--- a/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
@@ -42,7 +42,7 @@ class FilesInTest extends \unittest\TestCase {
     $loader= new FilesIn(self::$temp);
     $this->assertEquals(
       'Mustache template {{id}}',
-      $loader->source('test')->tokens()->nextToken("\n")
+      $loader->source('test')->code()
     );
   }
 

--- a/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
@@ -3,7 +3,6 @@
 use com\github\mustache\FilesIn;
 use com\github\mustache\TemplateNotFoundException;
 use lang\System;
-use io\streams\Streams;
 use io\Folder;
 use io\File;
 use io\FileUtil;
@@ -43,13 +42,13 @@ class FilesInTest extends \unittest\TestCase {
     $loader= new FilesIn(self::$temp);
     $this->assertEquals(
       'Mustache template {{id}}',
-      Streams::readAll($loader->load('test'))
+      $loader->load('test')->tokens()->nextToken("\n")
     );
   }
 
-  #[@test, @expect(TemplateNotFoundException::class)]
+  #[@test]
   public function load_non_existant() {
-    (new FilesIn(self::$temp))->load('@non.existant@');
+    $this->assertFalse((new FilesIn(self::$temp))->load('@non.existant@')->exists());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/FilesInTest.class.php
@@ -38,17 +38,17 @@ class FilesInTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function load_from_default_class_loader() {
+  public function source_from_default_class_loader() {
     $loader= new FilesIn(self::$temp);
     $this->assertEquals(
       'Mustache template {{id}}',
-      $loader->load('test')->tokens()->nextToken("\n")
+      $loader->source('test')->tokens()->nextToken("\n")
     );
   }
 
   #[@test]
-  public function load_non_existant() {
-    $this->assertFalse((new FilesIn(self::$temp))->load('@non.existant@')->exists());
+  public function source_non_existant() {
+    $this->assertFalse((new FilesIn(self::$temp))->source('@non.existant@')->exists());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
@@ -1,8 +1,6 @@
 <?php namespace com\github\mustache\unittest;
 
 use com\github\mustache\InMemory;
-use com\github\mustache\TemplateNotFoundException;
-use io\streams\Streams;
 
 class InMemoryTest extends \unittest\TestCase {
 
@@ -10,12 +8,12 @@ class InMemoryTest extends \unittest\TestCase {
   public function load() {
     $content= 'Mustache template {{id}}';
     $loader= new InMemory(['test' => $content]);
-    $this->assertEquals($content, Streams::readAll($loader->load('test')));
+    $this->assertEquals($content, $loader->load('test')->tokens()->nextToken("\n"));
   }
 
-  #[@test, @expect(TemplateNotFoundException::class)]
+  #[@test]
   public function load_non_existant() {
-    (new InMemory())->load('@non.existant@');
+    $this->assertFalse((new InMemory())->load('@non.existant@')->exists());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
@@ -5,15 +5,15 @@ use com\github\mustache\InMemory;
 class InMemoryTest extends \unittest\TestCase {
 
   #[@test]
-  public function load() {
+  public function source() {
     $content= 'Mustache template {{id}}';
     $loader= new InMemory(['test' => $content]);
-    $this->assertEquals($content, $loader->load('test')->tokens()->nextToken("\n"));
+    $this->assertEquals($content, $loader->source('test')->tokens()->nextToken("\n"));
   }
 
   #[@test]
-  public function load_non_existant() {
-    $this->assertFalse((new InMemory())->load('@non.existant@')->exists());
+  public function source_non_existant() {
+    $this->assertFalse((new InMemory())->source('@non.existant@')->exists());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/InMemoryTest.class.php
@@ -8,7 +8,7 @@ class InMemoryTest extends \unittest\TestCase {
   public function source() {
     $content= 'Mustache template {{id}}';
     $loader= new InMemory(['test' => $content]);
-    $this->assertEquals($content, $loader->source('test')->tokens()->nextToken("\n"));
+    $this->assertEquals($content, $loader->source('test')->code());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -10,7 +10,7 @@ class ResourcesInTest extends \unittest\TestCase {
     $loader= new ResourcesIn(ClassLoader::getDefault());
     $this->assertEquals(
       'Mustache template {{id}}',
-      $loader->source('com/github/mustache/unittest/template')->tokens()->nextToken("\n")
+      $loader->source('com/github/mustache/unittest/template')->code()
     );
   }
 

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -6,17 +6,17 @@ use lang\ClassLoader;
 class ResourcesInTest extends \unittest\TestCase {
 
   #[@test]
-  public function load_from_default_class_loader() {
+  public function source_from_default_class_loader() {
     $loader= new ResourcesIn(ClassLoader::getDefault());
     $this->assertEquals(
       'Mustache template {{id}}',
-      $loader->load('com/github/mustache/unittest/template')->tokens()->nextToken("\n")
+      $loader->source('com/github/mustache/unittest/template')->tokens()->nextToken("\n")
     );
   }
 
   #[@test]
-  public function load_non_existant() {
-    $this->assertFalse((new ResourcesIn(ClassLoader::getDefault()))->load('@non.existant@')->exists());
+  public function source_non_existant() {
+    $this->assertFalse((new ResourcesIn(ClassLoader::getDefault()))->source('@non.existant@')->exists());
   }
 
   #[@test]

--- a/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ResourcesInTest.class.php
@@ -1,9 +1,7 @@
 <?php namespace com\github\mustache\unittest;
 
 use com\github\mustache\ResourcesIn;
-use com\github\mustache\TemplateNotFoundException;
 use lang\ClassLoader;
-use io\streams\Streams;
 
 class ResourcesInTest extends \unittest\TestCase {
 
@@ -12,13 +10,13 @@ class ResourcesInTest extends \unittest\TestCase {
     $loader= new ResourcesIn(ClassLoader::getDefault());
     $this->assertEquals(
       'Mustache template {{id}}',
-      Streams::readAll($loader->load('com/github/mustache/unittest/template'))
+      $loader->load('com/github/mustache/unittest/template')->tokens()->nextToken("\n")
     );
   }
 
-  #[@test, @expect(TemplateNotFoundException::class)]
+  #[@test]
   public function load_non_existant() {
-    (new ResourcesIn(ClassLoader::getDefault()))->load('@non.existant@');
+    $this->assertFalse((new ResourcesIn(ClassLoader::getDefault()))->load('@non.existant@')->exists());
   }
 
   #[@test]


### PR DESCRIPTION
Instead of throwing an exception when load() is called, an Input instance is returned. Its exists() method can be used to test whether the loaded template exists.

### Old code
Needs to use exceptions for flow control...
```php
$previous= $templates->register('@partial-block', $this->fn);
try {
  return $context->engine->transform($this->name, $context, $this->start, $this->end, '');
} catch (TemplateNotFoundException $e) {
  return $this->fn->evaluate($context);
} finally {
  $templates->register('@partial-block', $previouss);
}
```

### New code
Longer but can use exists() to check for templates
```php
$source= $templates->source($this->name);
if ($source->exists()) {
  $previous= $templates->register('@partial-block', $this->fn);
  try {
    return $context->engine->render($source, $context, $this->start, $this->end, '');
  } finally {
    $templates->register('@partial-block', $previous);
  }
} else {
  return $this->fn->evaluate($context);
}
```

See https://github.com/xp-forge/handlebars/pull/9#pullrequestreview-63223047