### PR TITLE
Add MustacheEngine::write()...

### DIFF
--- a/src/main/php/com/github/mustache/CommentNode.class.php
+++ b/src/main/php/com/github/mustache/CommentNode.class.php
@@ -29,10 +29,10 @@ class CommentNode extends Node {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
-    return '';
+  public function write($context, $out) {
+    // NOOP
   }
 
   /**

--- a/src/main/php/com/github/mustache/IteratorNode.class.php
+++ b/src/main/php/com/github/mustache/IteratorNode.class.php
@@ -39,16 +39,16 @@ class IteratorNode extends Node {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
+  public function write($context, $out) {
     $value= $context->lookup(null);     // Current
     if ($context->isHash($value) || $context->isList($value)) {
       $v= current($context->asTraversable($value));
     } else {
       $v= $value;
     }
-    return $this->escape ? htmlspecialchars($v) : $v;
+    $out->write($this->escape ? htmlspecialchars($v) : $v);
   }
 
   /**

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -137,7 +137,26 @@ class MustacheEngine {
     } else {
       $c= new DataContext($context);
     }
+    
     return $template->evaluate($c->withEngine($this));
+  }
+
+  /**
+   * Evaluates a compiled template and writes to a given output stream
+   *
+   * @param  com.github.mustache.Template $template The template
+   * @param  com.github.mustache.Context|[:var] $context The context
+   * @param  io.streams.OutputStream $out
+   * @return void
+   */
+  public function write(Template $template, $context, $out) {
+    if ($context instanceof Context) {
+      $c= $context;
+    } else {
+      $c= new DataContext($context);
+    }
+    
+    $template->write($c->withEngine($this), $out);
   }
 
   /**

--- a/src/main/php/com/github/mustache/Node.class.php
+++ b/src/main/php/com/github/mustache/Node.class.php
@@ -15,7 +15,7 @@ abstract class Node implements Value {
    * @param  com.github.mustache.Context $context the rendering context
    * @return string
    */
-  public final function evaluate($context) {
+  public function evaluate($context) {
     $out= new MemoryOutputStream();
     $this->write($context, $out);
     return $out->getBytes();
@@ -28,7 +28,14 @@ abstract class Node implements Value {
    * @param  io.streams.OutputStream $out
    * @return void
    */
-  public abstract function write($context, $out);
+  public function write($context, $out) {
+
+    // BC: Subclasses of earlier versions of this class overwrote the
+    // evaluate() method, so keep this method non-abstract (and write()
+    // non-final, both of which prevent endless loops if incorrectly
+    // subclassed!) and provide a default behavior for the old way.
+    $out->write($this->evaluate($context));
+  }
 
   /**
    * Overload (string) cast. Overwrite this in implementing subclasses!

--- a/src/main/php/com/github/mustache/Node.class.php
+++ b/src/main/php/com/github/mustache/Node.class.php
@@ -1,10 +1,13 @@
 <?php namespace com\github\mustache;
 
+use io\streams\MemoryOutputStream;
+use lang\Value;
+
 /**
  * A node represents any tag inside a mustache document, e.g.
  * variables, sections or partials.
  */
-abstract class Node implements \lang\Value {
+abstract class Node implements Value {
 
   /**
    * Evaluates this node
@@ -12,10 +15,23 @@ abstract class Node implements \lang\Value {
    * @param  com.github.mustache.Context $context the rendering context
    * @return string
    */
-  public abstract function evaluate($context);
+  public final function evaluate($context) {
+    $out= new MemoryOutputStream();
+    $this->write($context, $out);
+    return $out->getBytes();
+  }
 
   /**
-   * Overload (string) cast
+   * Writes this node. Overwrite this in implementing subclasses!
+   *
+   * @param  com.github.mustache.Context $context the rendering context
+   * @param  io.streams.OutputStream $out
+   * @return void
+   */
+  public abstract function write($context, $out);
+
+  /**
+   * Overload (string) cast. Overwrite this in implementing subclasses!
    *
    * @return string
    */
@@ -32,12 +48,8 @@ abstract class Node implements \lang\Value {
   }
 
   /** @return string */
-  public function hashCode() {
-    return md5($this->__toString());
-  }
+  public function hashCode() { return md5($this->__toString()); }
 
   /** @return string */
-  public function toString() {
-    return nameof($this);
-  }
+  public function toString() { return nameof($this); }
 }

--- a/src/main/php/com/github/mustache/NodeList.class.php
+++ b/src/main/php/com/github/mustache/NodeList.class.php
@@ -73,14 +73,12 @@ class NodeList extends Node implements \ArrayAccess, \IteratorAggregate {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
-    $output= '';
+  public function write($context, $out) {
     foreach ($this->nodes as $node) {
-      $output.= $node->evaluate($context);
+      $node->write($context, $out);
     }
-    return $output;
   }
 
   /**

--- a/src/main/php/com/github/mustache/PartialNode.class.php
+++ b/src/main/php/com/github/mustache/PartialNode.class.php
@@ -45,7 +45,8 @@ class PartialNode extends Node {
    */
   public function write($context, $out) {
     try {
-      $out->write($context->engine->transform($this->name, $context, '{{', '}}', $this->indent));
+      $template= $context->engine->load($this->name, '{{', '}}', $this->indent);
+      $template->write($context, $out);
     } catch (TemplateNotFoundException $e) {
       // Spec dictates this, though I think this is not good behaviour.
     }

--- a/src/main/php/com/github/mustache/PartialNode.class.php
+++ b/src/main/php/com/github/mustache/PartialNode.class.php
@@ -47,7 +47,7 @@ class PartialNode extends Node {
     try {
       $out->write($context->engine->transform($this->name, $context, '{{', '}}', $this->indent));
     } catch (TemplateNotFoundException $e) {
-      return;    // Spec dictates this, though I think this is not good behaviour.
+      // Spec dictates this, though I think this is not good behaviour.
     }
   }
 

--- a/src/main/php/com/github/mustache/PartialNode.class.php
+++ b/src/main/php/com/github/mustache/PartialNode.class.php
@@ -41,13 +41,13 @@ class PartialNode extends Node {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
+  public function write($context, $out) {
     try {
-      return $context->engine->transform($this->name, $context, '{{', '}}', $this->indent);
+      $out->write($context->engine->transform($this->name, $context, '{{', '}}', $this->indent));
     } catch (TemplateNotFoundException $e) {
-      return '';    // Spec dictates this, though I think this is not good behaviour.
+      return;    // Spec dictates this, though I think this is not good behaviour.
     }
   }
 

--- a/src/main/php/com/github/mustache/Template.class.php
+++ b/src/main/php/com/github/mustache/Template.class.php
@@ -39,13 +39,13 @@ class Template extends Node {
   }
 
   /**
-   * Evaluates this node
+   * Write this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
-    return $this->root->evaluate($context);
+  public function write($context, $out) {
+    $this->root->write($context, $out);
   }
 
   /**

--- a/src/main/php/com/github/mustache/TextNode.class.php
+++ b/src/main/php/com/github/mustache/TextNode.class.php
@@ -47,10 +47,10 @@ class TextNode extends Node {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
-    return $this->text;
+  public function write($context, $out) {
+    $out->write($this->text);
   }
 
   /**

--- a/src/main/php/com/github/mustache/VariableNode.class.php
+++ b/src/main/php/com/github/mustache/VariableNode.class.php
@@ -84,16 +84,16 @@ class VariableNode extends Node {
    * Evaluates this node
    *
    * @param  com.github.mustache.Context $context the rendering context
-   * @return string
+   * @param  io.streams.OutputStream $out
    */
-  public function evaluate($context) {
+  public function write($context, $out) {
     $value= $context->lookup($this->name);
     if ($context->isCallable($value)) {
       $rendered= $context->asRendering($value, $this, $this->options);
     } else {
       $rendered= $context->asString($value);
     }
-    return $this->escape ? htmlspecialchars($rendered) : $rendered;
+    $out->write($this->escape ? htmlspecialchars($rendered) : $rendered);
   }
 
   /**

--- a/src/test/php/com/github/mustache/unittest/ParserExtendingTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ParserExtendingTest.class.php
@@ -10,7 +10,7 @@ class ParserExtendingTest extends \unittest\TestCase {
   #[@test]
   public function new_user_handler_as_function() {
     $node= newinstance(Node::class, [], '{
-      public function evaluate($context) { return "test"; }
+      public function write($context, $out) { $out->write("test"); }
       public function __toString() { return "*test"; }
     }');
 

--- a/src/test/php/com/github/mustache/unittest/ParserExtendingTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/ParserExtendingTest.class.php
@@ -19,4 +19,17 @@ class ParserExtendingTest extends \unittest\TestCase {
     });
     $this->assertEquals(new NodeList([$node]), $parser->parse(new StringTokenizer('{{*test}}')));
   }
+
+  #[@test]
+  public function new_user_handler_as_function_bc_evaluate() {
+    $node= newinstance(Node::class, [], '{
+      public function evaluate($context) { return "test"; }
+      public function __toString() { return "*test"; }
+    }');
+
+    $parser= (new MustacheParser())->withHandler('*', true, function($tag, $state) use($node) {
+      $state->target->add($node);
+    });
+    $this->assertEquals(new NodeList([$node]), $parser->parse(new StringTokenizer('{{*test}}')));
+  }
 }


### PR DESCRIPTION
...which is like evaluate() but writes to a stream instead of returning the contents as a string:

```php
$engine= new MustacheEngine();
$template= $engine->compile('Hello {{name}}');

// Evaluate to a string
$transform= $engine->evaluate($template, ['name' => 'Test']);

// Evaluate and write to an output stream
$out= new FileOutputstream('result.txt');
try {
  $engine->write($template, ['name' => 'Test'], $out);
} finally {
  $out->close();
}
```