### PR TITLE
Replace Tokens class by two separate & use-case optimized versions

### DIFF
--- a/src/main/php/com/github/mustache/AbstractMustacheParser.class.php
+++ b/src/main/php/com/github/mustache/AbstractMustacheParser.class.php
@@ -74,7 +74,7 @@ abstract class AbstractMustacheParser implements TemplateParser {
   /**
    * Parse a template
    *
-   * @param  string $template The template as a string
+   * @param  text.Tokenizer $tokens A tokenizer on the given template
    * @param  string $start Initial start tag, defaults to "{{"
    * @param  string $end Initial end tag, defaults to "}}"
    * @param  string $indent What to prefix before each line

--- a/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
+++ b/src/main/php/com/github/mustache/FileBasedTemplateLoader.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\github\mustache;
 
-use com\github\mustache\templates\{NotFound, Templates, Tokens};
+use com\github\mustache\templates\{NotFound, Templates, FromStream};
 use text\StreamTokenizer;
 use util\Objects;
 
@@ -54,7 +54,7 @@ abstract class FileBasedTemplateLoader extends Templates {
   public function source($name) {
     $variants= $this->variantsOf($name);
     foreach ($variants as $variant) {
-      if ($stream= $this->inputStreamFor($variant)) return new Tokens($variant, new StreamTokenizer($stream));
+      if ($stream= $this->inputStreamFor($variant)) return new FromStream($variant, $stream);
     }
 
     return new NotFound('Cannot find template ['.implode(', ', $variants).'] in '.Objects::stringOf($this->base));

--- a/src/main/php/com/github/mustache/InMemory.class.php
+++ b/src/main/php/com/github/mustache/InMemory.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\github\mustache;
 
-use com\github\mustache\templates\{NotFound, Templates, Tokens};
+use com\github\mustache\templates\{NotFound, Templates, InString};
 use text\StringTokenizer;
 
 /**
@@ -63,7 +63,7 @@ class InMemory extends Templates {
    */
   public function source($name) {
     if (isset($this->templates[$name])) {
-      return new Tokens($name, new StringTokenizer($this->templates[$name]));
+      return new InString($name, $this->templates[$name]);
     } else {
       return new NotFound('Cannot find template '.$name);
     }

--- a/src/main/php/com/github/mustache/templates/FromLoader.class.php
+++ b/src/main/php/com/github/mustache/templates/FromLoader.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\github\mustache\templates;
 
 use com\github\mustache\WithListing;
-use com\github\mustache\templates\Tokens;
+use com\github\mustache\templates\FromStream;
 use lang\IllegalAccessException;
 use text\StreamTokenizer;
 
@@ -22,11 +22,11 @@ class FromLoader extends Templates {
    * Load a template by a given name
    *
    * @param  string $name The template name, not including the file extension
-   * @return com.github.mustache.TemplateSource
+   * @return com.github.mustache.templates.Source
    */
   public function source($name) {
     try {
-      return new Tokens($name, new StreamTokenizer($this->loader->load($name)));
+      return new FromStream($name, $this->loader->load($name));
     } catch (TemplateNotFoundException $e) {
       return new NotFound($e->getMessage());
     }

--- a/src/main/php/com/github/mustache/templates/FromStream.class.php
+++ b/src/main/php/com/github/mustache/templates/FromStream.class.php
@@ -1,0 +1,37 @@
+<?php namespace com\github\mustache\templates;
+
+use com\github\mustache\Template;
+use io\streams\{InputStream, Streams};
+use text\StreamTokenizer;
+
+/** A template sourced from a given stream */
+class FromStream extends Source {
+  private $name, $stream;
+
+  /**
+   * Creates a new token name
+   *
+   * @param  string $name
+   * @param  io.streams.InputStream $stream
+   */
+  public function __construct($name, InputStream $stream) {
+    $this->name= $name;
+    $this->stream= $stream;
+  }
+
+  /** @return string */
+  public function code() { return Streams::readAll($this->stream); }
+
+  /**
+   * Compiles this source into a template
+   *
+   * @param  com.github.mustache.MustacheParser $parser
+   * @param  string $start
+   * @param  string $end
+   * @param  string $indent
+   * @return com.github.mustache.Template
+   */
+  public function compile($parser, $start, $end, $indent) {
+    return new Template($this->name, $parser->parse(new StreamTokenizer($this->stream), $start, $end, $indent));
+  }
+}

--- a/src/main/php/com/github/mustache/templates/InString.class.php
+++ b/src/main/php/com/github/mustache/templates/InString.class.php
@@ -1,0 +1,36 @@
+<?php namespace com\github\mustache\templates;
+
+use com\github\mustache\Template;
+use text\StringTokenizer;
+
+/** A template sourced in a given string */
+class InString extends Source {
+  private $name, $source;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  string $name
+   * @param  string $source
+   */
+  public function __construct($name, $source) {
+    $this->name= $name;
+    $this->source= $source;
+  }
+
+  /** @return string */
+  public function code() { return $this->source; }
+
+  /**
+   * Compiles this source into a template
+   *
+   * @param  com.github.mustache.MustacheParser $parser
+   * @param  string $start
+   * @param  string $end
+   * @param  string $indent
+   * @return com.github.mustache.Template
+   */
+  public function compile($parser, $start, $end, $indent) {
+    return new Template($this->name, $parser->parse(new StringTokenizer($this->source), $start, $end, $indent));
+  }
+}

--- a/src/main/php/com/github/mustache/templates/Tokens.class.php
+++ b/src/main/php/com/github/mustache/templates/Tokens.class.php
@@ -2,6 +2,7 @@
 
 use com\github\mustache\Template;
 
+/** @deprecated Replaced by FromStream and InString classes */
 class Tokens extends Source {
   private $source, $tokens;
 
@@ -18,6 +19,8 @@ class Tokens extends Source {
 
   /** @return string */
   public function code() {
+
+    // Detour: Tokenize input, concatenating it back into a string
     $this->tokens->returnDelims= true;
     try {
       $s= '';


### PR DESCRIPTION
This way, the `code()` method doesn't need to go the detour of tokenizing the input to simply concatenate all tokens into a string again:

```php
class Tokens extends Source {
  // ..

  public function code() {

    // Detour: Tokenize input, concatenating it back into a string
    $this->tokens->returnDelims= true;
    try {
      $s= '';
      while ($this->tokens->hasMoreTokens()) {
        $s.= $this->tokens->nextToken();
      }
      return $s;
    } finally {
      $this->tokens->returnDelims= false;
    }
  }

  // ..
}
```

In the new classes `com.github.mustache.templates.FromStream` and com.github.mustache.templates.InString`, this method can be replaced by a one-liner.