### PR TITLE
Introduce concept of scopes, with the engine simply being one.

### DIFF
--- a/src/main/php/com/github/mustache/Context.class.php
+++ b/src/main/php/com/github/mustache/Context.class.php
@@ -8,7 +8,7 @@
 abstract class Context {
   public $variables= [];
   public $parent= null;
-  public $engine= null;
+  public $scope= null;
 
   /**
    * Creates a new context instance
@@ -20,21 +20,18 @@ abstract class Context {
     $this->variables= $variables;
     if ($parent) {
       $this->parent= $parent;
-      $this->engine= $parent->engine;
-    } else {
-      $this->parent= null;
-      $this->engine= null;
+      $this->scope= $parent->scope;
     }
   }
 
   /**
-   * Sets engine and returns this context instance.
+   * Sets scope and returns this context instance.
    *
-   * @param  com.github.mustache.MustacheEngine $engine
+   * @param  com.github.mustache.Scope $scope
    * @return self
    */
-  public function withEngine($engine) {
-    $this->engine= $engine;
+  public function inScope($scope) {
+    $this->scope= $scope;
     return $this;
   }
 
@@ -159,7 +156,7 @@ abstract class Context {
     foreach ($options as $key => $option) {
       $pass[$key]= $this->isCallable($option) ? $option($node, $this, $pass) : $option;
     }
-    return $this->engine->render($closure($node, $this, $pass), $this, $start, $end);
+    return $this->scope->render($closure($node, $this, $pass), $this, $start, $end);
   }
 
   /**
@@ -219,7 +216,7 @@ abstract class Context {
 
     // Last resort: Check helpers
     if (null === $v && $helpers) {
-      $v= $this->engine->helpers;
+      $v= $this->scope->helpers;
       foreach ($segments as $segment) {
         if ($v !== null) $v= $this->helper($v, $segment);
       }

--- a/src/main/php/com/github/mustache/MustacheEngine.class.php
+++ b/src/main/php/com/github/mustache/MustacheEngine.class.php
@@ -22,9 +22,8 @@ use text\StringTokenizer;
  * @see  https://github.com/mustache/spec
  * @see  http://mustache.github.io/mustache.5.html
  */
-class MustacheEngine {
-  protected $templates, $parser;
-  public $helpers= [];
+class MustacheEngine extends Scope {
+  protected $parser;
 
   /**
    * Constructor. Initializes template loader
@@ -52,6 +51,7 @@ class MustacheEngine {
   /**
    * Gets used template loader
    *
+   * @deprecated Use public member instead
    * @return com.github.mustache.Templates
    */
   public function getTemplates() {
@@ -130,13 +130,8 @@ class MustacheEngine {
    * @return string The rendered output
    */
   public function evaluate(Template $template, $context) {
-    if ($context instanceof Context) {
-      $c= $context;
-    } else {
-      $c= new DataContext($context);
-    }
-    
-    return $template->evaluate($c->withEngine($this));
+    $c= $context instanceof Context ? $context : new DataContext($context);
+    return $template->evaluate($c->inScope($this));
   }
 
   /**
@@ -148,13 +143,8 @@ class MustacheEngine {
    * @return void
    */
   public function write(Template $template, $context, $out) {
-    if ($context instanceof Context) {
-      $c= $context;
-    } else {
-      $c= new DataContext($context);
-    }
-    
-    $template->write($c->withEngine($this), $out);
+    $c= $context instanceof Context ? $context : new DataContext($context);
+    $template->write($c->inScope($this), $out);
   }
 
   /**

--- a/src/main/php/com/github/mustache/PartialNode.class.php
+++ b/src/main/php/com/github/mustache/PartialNode.class.php
@@ -45,7 +45,7 @@ class PartialNode extends Node {
    */
   public function write($context, $out) {
     try {
-      $template= $context->engine->load($this->name, '{{', '}}', $this->indent);
+      $template= $context->scope->load($this->name, '{{', '}}', $this->indent);
       $template->write($context, $out);
     } catch (TemplateNotFoundException $e) {
       // Spec dictates this, though I think this is not good behaviour.

--- a/src/main/php/com/github/mustache/Scope.class.php
+++ b/src/main/php/com/github/mustache/Scope.class.php
@@ -1,0 +1,10 @@
+<?php namespace com\github\mustache;
+
+class Scope {
+  public $helpers= [];
+  public $templates= null;
+
+  public function load($name) {
+    
+  }
+}

--- a/src/test/php/com/github/mustache/unittest/DataContextTest.class.php
+++ b/src/test/php/com/github/mustache/unittest/DataContextTest.class.php
@@ -13,7 +13,7 @@ class DataContextTest {
    * @return com.github.mustache.Context
    */
   public function newFixture($variables, $helpers= []) {
-    return (new DataContext($variables))->withEngine((new MustacheEngine())->withHelpers($helpers));
+    return (new DataContext($variables))->inScope((new MustacheEngine())->withHelpers($helpers));
   }
 
   #[Test]


### PR DESCRIPTION
This opens possibilities to render contexts in different scopes, e.g. a HTTP request scope, which then pass language and internationalization preferences

## Refactoring

* [x] Create `com.github.mustache.Scope` class
* [x] Sublass MustacheEngine from this new class 
* [x] Create `Context::inScope()` to replace `::withEngine()` (*BC break here at the moment, we might add compatibility later*)
* [ ] Move parser instances to templates mechanism

See xp-forge/handlebars-templates#1